### PR TITLE
Update clickhouse for faster startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 
 dependencies {
-    implementation("com.clickhouse:clickhouse-http-client:0.6.1")
+    implementation("com.clickhouse:clickhouse-http-client:0.6.4")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.3")
 
     implementation(platform("io.opentelemetry:opentelemetry-bom:1.39.0"));

--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,6 @@
 
 ./gradlew shadowJar
 
-#cp /Users/jay/code/projects/opentelemetry-java-instrumentation/javaagent/build/libs/opentelemetry-javaagent-2.5.0-SNAPSHOT.jar opentelemetry-javaagent.jar
-
 java -javaagent:opentelemetry-javaagent.jar \
      -Dotel.resource.attributes=service.name=test-service \
      -Dotel.traces.exporter=otlp \


### PR DESCRIPTION
Updates java agent to 2.7.0, updates clickhouse client to `0.6.4` to take advantage of a fix where they improved startup speed.

Previously would take 25+ seconds to startup, now everything runs in under 300ms

before/ after:

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/3f281ab4-92c4-49d1-b843-8ca9c215886b">
